### PR TITLE
change API URL to temporary for new hosting

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,4 +1,4 @@
-var api = 'https://explorer.bbscoin.xyz';
+var api = 'https://bbs-node.tradecrypto.click';
 var blockTargetInterval = 120;
 var coinUnits = 100000000;
 var symbol = 'BBS';


### PR DESCRIPTION
Will be hosting the websites on my servers. When the domain DNS is transferred to me to point to my servers, then I will generate the correct hostname again.